### PR TITLE
Update Gradle plugin to 1.2.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:1.1.3'
+    classpath 'com.android.tools.build:gradle:1.2.3'
   }
 }
 


### PR DESCRIPTION
With the previous plugin is not working on Android Studio 1.2, the build system can't download dependencies like RxJava.
